### PR TITLE
minimal set of changes for bevy 0.11

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bevy_ninepatch"
-version = "0.10.0"
+version = "0.11.0"
 authors = ["François Mockers <mockersf@gmail.com>"]
 edition = "2021"
 description = "Displays 9-Patch UI elements in Bevy"
@@ -13,12 +13,12 @@ readme = "README.md"
 exclude = ["examples/*.png", "examples/*.gif", "*.png", "assets/"]
 
 [dependencies.bevy]
-version = "0.10"
+version = "0.11"
 default-features = false
 features = [ "bevy_ui", "bevy_render", "bevy_sprite", "bevy_asset" ]
 
 [dev-dependencies.bevy]
-version = "0.10"
+version = "0.11"
 default-features = false
 features = [ "bevy_text", "bevy_ui", "bevy_render", "bevy_sprite", "bevy_asset" ]
 

--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@ See [full.rs example](https://github.com/vleue/bevy_ninepatch/blob/main/examples
 |Bevy|bevy_ninepatch|
 |---|---|
 |main|main|
+|0.11|0.11|
 |0.10|0.10|
 |0.9|0.9|
 |0.8|0.8|

--- a/examples/change_size.rs
+++ b/examples/change_size.rs
@@ -4,12 +4,14 @@ use bevy_ninepatch::{NinePatchBuilder, NinePatchBundle, NinePatchData, NinePatch
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     App::default()
-        .add_plugins(DefaultPlugins)
-        // Add the `NinePatchPlugin` plugin
-        .add_plugin(NinePatchPlugin::<()>::default())
-        .add_startup_system(setup)
+        .add_plugins((
+            DefaultPlugins,
+            // Add the `NinePatchPlugin` plugin
+            NinePatchPlugin::<()>::default(),
+        ))
+        .add_systems(Startup, setup)
         // this system will change the size depending on time elapsed since startup
-        .add_system(update_size)
+        .add_systems(Update, update_size)
         .run();
 
     Ok(())
@@ -33,7 +35,8 @@ fn setup(
                 margin: UiRect::all(Val::Auto),
                 justify_content: JustifyContent::Center,
                 align_items: AlignItems::Center,
-                size: Size::new(Val::Px(50.), Val::Px(50.)),
+                width: Val::Px(50.),
+                height: Val::Px(50.),
                 ..Default::default()
             },
             nine_patch_data: NinePatchData {
@@ -53,7 +56,7 @@ fn update_size(time: Res<Time>, mut query: Query<&mut Style, With<NinePatchData<
     for mut style in query.iter_mut() {
         let (x, y) = time.elapsed_seconds().sin_cos();
 
-        style.size.width = Val::Px((250. + 200. * x as f32).ceil());
-        style.size.height = Val::Px((250. + 200. * y as f32).ceil());
+        style.width = Val::Px((250. + 200. * x as f32).ceil());
+        style.height = Val::Px((250. + 200. * y as f32).ceil());
     }
 }

--- a/examples/content.rs
+++ b/examples/content.rs
@@ -6,11 +6,13 @@ use bevy_ninepatch::{
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     App::default()
-        .add_plugins(DefaultPlugins)
-        // Add the `NinePatchPlugin` plugin
-        .add_plugin(NinePatchPlugin::<()>::default())
-        .add_startup_system(setup)
-        .add_system(set_content)
+        .add_plugins((
+            DefaultPlugins,
+            // Add the `NinePatchPlugin` plugin
+            NinePatchPlugin::<()>::default(),
+        ))
+        .add_systems(Startup, setup)
+        .add_systems(Update, set_content)
         .run();
 
     Ok(())
@@ -34,7 +36,8 @@ fn setup(
                 margin: UiRect::all(Val::Auto),
                 justify_content: JustifyContent::Center,
                 align_items: AlignItems::Center,
-                size: Size::new(Val::Px(500.), Val::Px(300.)),
+                width: Val::Px(500.),
+                height: Val::Px(300.),
                 ..Default::default()
             },
             nine_patch_data: NinePatchData {

--- a/examples/full.rs
+++ b/examples/full.rs
@@ -1,21 +1,25 @@
 use bevy::{
     diagnostic::{FrameTimeDiagnosticsPlugin, LogDiagnosticsPlugin},
-    prelude::*,
+    prelude::*, reflect::TypePath,
 };
 
 use bevy_ninepatch::*;
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     App::default()
-        .add_plugins(DefaultPlugins)
-        // Add the `NinePatchPlugin` plugin
-        .add_plugin(NinePatchPlugin::<Content>::default())
-        .add_plugin(FrameTimeDiagnosticsPlugin::default())
+        .add_plugins((
+            DefaultPlugins,
+            // Add the `NinePatchPlugin` plugin
+            NinePatchPlugin::<Content>::default(),
+            FrameTimeDiagnosticsPlugin::default(),
+            LogDiagnosticsPlugin::default()
+        ))
         // Adds a system that prints diagnostics to the console
-        .add_plugin(LogDiagnosticsPlugin::default())
-        .add_startup_system(setup)
-        .add_system(set_content)
-        .add_system(update_size)
+        .add_systems(Startup, setup)
+        .add_systems(Update, (
+            set_content,
+            update_size
+        ))
         .run();
 
     Ok(())
@@ -34,32 +38,32 @@ fn setup(
             // top left corner patch
             Patch {
                 original_size: IVec2::new(30, 35),
-                target_size: Size::new(Val::Undefined, Val::Undefined),
+                target_size: Size::new(Val::Px(0.), Val::Px(0.)),
                 content: None,
             },
             // top middle-left patch. This patch width can grow, and will contain the content for
             // `PanelContent::Title`
             Patch {
                 original_size: IVec2::new(15, 35),
-                target_size: Size::new(Val::Percent(30.), Val::Undefined),
+                target_size: Size::new(Val::Percent(30.), Val::Px(0.)),
                 content: Some(Content::Title),
             },
             // top middle patch. In the original PNG, it's the yellow titled part
             Patch {
                 original_size: IVec2::new(25, 35),
-                target_size: Size::new(Val::Undefined, Val::Undefined),
+                target_size: Size::new(Val::Px(0.), Val::Px(0.)),
                 content: None,
             },
             // top middle-right patch. This patch width can grow
             Patch {
                 original_size: IVec2::new(20, 35),
-                target_size: Size::new(Val::Percent(70.), Val::Undefined),
+                target_size: Size::new(Val::Percent(70.), Val::Px(0.)),
                 content: None,
             },
             // top right corner
             Patch {
                 original_size: IVec2::new(10, 35),
-                target_size: Size::new(Val::Undefined, Val::Undefined),
+                target_size: Size::new(Val::Px(0.), Val::Px(0.)),
                 content: None,
             },
         ],
@@ -67,7 +71,7 @@ fn setup(
             // left border. This patch height can grow
             Patch {
                 original_size: IVec2::new(10, -45),
-                target_size: Size::new(Val::Undefined, Val::Percent(100.)),
+                target_size: Size::new(Val::Px(0.), Val::Percent(100.)),
                 content: None,
             },
             // center. This patch can grow both in height and width, and will contain `PanelContent::Body`
@@ -79,7 +83,7 @@ fn setup(
             // right border. This patch height can grow
             Patch {
                 original_size: IVec2::new(10, -45),
-                target_size: Size::new(Val::Undefined, Val::Percent(100.)),
+                target_size: Size::new(Val::Px(0.), Val::Percent(100.)),
                 content: None,
             },
         ],
@@ -87,19 +91,19 @@ fn setup(
             // bottom left corner
             Patch {
                 original_size: IVec2::new(10, 10),
-                target_size: Size::new(Val::Undefined, Val::Undefined),
+                target_size: Size::new(Val::Px(0.), Val::Px(0.)),
                 content: None,
             },
             // bottom middle. This patch width can grow
             Patch {
                 original_size: IVec2::new(-20, 10),
-                target_size: Size::new(Val::Percent(100.), Val::Undefined),
+                target_size: Size::new(Val::Percent(100.), Val::Px(0.)),
                 content: None,
             },
             // bottom right corner
             Patch {
                 original_size: IVec2::new(10, 10),
-                target_size: Size::new(Val::Undefined, Val::Undefined),
+                target_size: Size::new(Val::Px(0.), Val::Px(0.)),
                 content: None,
             },
         ],
@@ -113,7 +117,8 @@ fn setup(
                 margin: UiRect::all(Val::Auto),
                 justify_content: JustifyContent::Center,
                 align_items: AlignItems::Center,
-                size: Size::new(Val::Px(900.), Val::Px(600.)),
+                width: Val::Px(900.),
+                height: Val::Px(600.),
                 ..Default::default()
             },
             nine_patch_data: NinePatchData {
@@ -165,7 +170,8 @@ fn set_content(
                                     margin: UiRect::all(Val::Auto),
                                     justify_content: JustifyContent::Center,
                                     align_items: AlignItems::Center,
-                                    size: Size::new(Val::Px(850.), Val::Px(550.)),
+                                    width: Val::Px(850.),
+                                    height: Val::Px(550.),
                                     ..Default::default()
                                 },
                                 nine_patch_data: NinePatchData {
@@ -194,7 +200,7 @@ fn set_content(
                             )
                             .with_style(Style {
                                 margin: UiRect {
-                                    left: Val::Undefined,
+                                    left: Val::Px(0.),
                                     right: Val::Auto,
                                     top: Val::Px(8.),
                                     bottom: Val::Auto,
@@ -225,7 +231,8 @@ fn set_content(
                                         top: Val::Auto,
                                         bottom: Val::Px(0.),
                                     },
-                                    size: Size::new(Val::Px(300.), Val::Px(80.)),
+                                    width: Val::Px(300.),
+                                    height: Val::Px(80.),
 
                                     justify_content: JustifyContent::Center,
                                     align_items: AlignItems::Center,
@@ -256,7 +263,8 @@ fn set_content(
                                     },
                                     justify_content: JustifyContent::Center,
                                     align_items: AlignItems::Center,
-                                    size: Size::new(Val::Px(300.), Val::Px(80.)),
+                                    width: Val::Px(300.),
+                                    height: Val::Px(80.),
                                     ..Default::default()
                                 },
                                 nine_patch_data: NinePatchData {
@@ -330,7 +338,7 @@ fn set_content(
     }
 }
 
-#[derive(Clone, PartialEq, Eq, std::hash::Hash)]
+#[derive(Clone, PartialEq, Eq, std::hash::Hash, TypePath)]
 enum Content {
     Title,
     Content,
@@ -351,15 +359,15 @@ fn update_size(time: Res<Time>, mut query: Query<(&mut Style, &UiElement)>) {
 
         match panel {
             UiElement::Panel => {
-                style.size.width = Val::Px((900. + 50. * x as f32).ceil());
-                style.size.height = Val::Px((600. + 50. * y as f32).ceil());
+                style.width = Val::Px((900. + 50. * x as f32).ceil());
+                style.height = Val::Px((600. + 50. * y as f32).ceil());
             }
             UiElement::InnerPanel => {
-                style.size.width = Val::Px((850. + 50. * x as f32).ceil());
-                style.size.height = Val::Px((550. + 50. * y as f32).ceil());
+                style.width = Val::Px((850. + 50. * x as f32).ceil());
+                style .height = Val::Px((550. + 50. * y as f32).ceil());
             }
-            UiElement::ButtonOK => style.size.width = Val::Px((300. + 50. * x as f32).ceil()),
-            UiElement::ButtonCancel => style.size.height = Val::Px((90. + 10. * y as f32).ceil()),
+            UiElement::ButtonOK => style.width = Val::Px((300. + 50. * x as f32).ceil()),
+            UiElement::ButtonCancel => style.height = Val::Px((90. + 10. * y as f32).ceil()),
         }
     }
 }

--- a/examples/multi_content_with_content_map.rs
+++ b/examples/multi_content_with_content_map.rs
@@ -4,10 +4,12 @@ use bevy_ninepatch::{NinePatchBuilder, NinePatchBundle, NinePatchData, NinePatch
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     App::default()
-        .add_plugins(DefaultPlugins)
-        // Add the `NinePatchPlugin` plugin
-        .add_plugin(NinePatchPlugin::<()>::default())
-        .add_startup_system(setup)
+        .add_plugins((
+            DefaultPlugins,
+            // Add the `NinePatchPlugin` plugin
+            NinePatchPlugin::<()>::default()
+        ))
+        .add_systems(Startup, setup)
         .run();
 
     Ok(())
@@ -65,7 +67,8 @@ fn setup(
                     },
                     justify_content: JustifyContent::Center,
                     align_items: AlignItems::Center,
-                    size: Size::new(Val::Px(200.), Val::Px(100.)),
+                    width: Val::Px(200.),
+                    height: Val::Px(100.),
                     ..Default::default()
                 },
                 nine_patch_data: NinePatchData {
@@ -91,7 +94,8 @@ fn setup(
                 margin: UiRect::all(Val::Auto),
                 justify_content: JustifyContent::Center,
                 align_items: AlignItems::Center,
-                size: Size::new(Val::Px(500.), Val::Px(300.)),
+                width: Val::Px(500.),
+                height: Val::Px(300.),
                 ..Default::default()
             },
             // helper method when there is only one content zone

--- a/examples/multi_content_with_system.rs
+++ b/examples/multi_content_with_system.rs
@@ -1,4 +1,4 @@
-use bevy::prelude::*;
+use bevy::{prelude::*, reflect::TypePath};
 
 use bevy_ninepatch::{
     NinePatchBuilder, NinePatchBundle, NinePatchContent, NinePatchData, NinePatchPlugin,
@@ -6,11 +6,13 @@ use bevy_ninepatch::{
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     App::default()
-        .add_plugins(DefaultPlugins)
-        // Add the `NinePatchPlugin` plugin
-        .add_plugin(NinePatchPlugin::<Content>::default())
-        .add_startup_system(setup)
-        .add_system(set_content)
+        .add_plugins((
+            DefaultPlugins,
+            // Add the `NinePatchPlugin` plugin
+            NinePatchPlugin::<Content>::default(),
+        ))
+        .add_systems(Startup, setup)
+        .add_systems(Update, set_content)
         .run();
 
     Ok(())
@@ -39,7 +41,8 @@ fn setup(
                 margin: UiRect::all(Val::Auto),
                 justify_content: JustifyContent::Center,
                 align_items: AlignItems::Center,
-                size: Size::new(Val::Px(500.), Val::Px(300.)),
+                width: Val::Px(500.),
+                height: Val::Px(300.),
                 ..Default::default()
             },
             nine_patch_data: NinePatchData {
@@ -84,7 +87,8 @@ fn set_content(
                                     },
                                     justify_content: JustifyContent::Center,
                                     align_items: AlignItems::Center,
-                                    size: Size::new(Val::Px(200.), Val::Px(100.)),
+                                    width: Val::Px(200.),
+                                    height: Val::Px(100.),
                                     ..Default::default()
                                 },
                                 nine_patch_data: NinePatchData {
@@ -132,7 +136,7 @@ fn set_content(
     }
 }
 
-#[derive(Clone, PartialEq, Eq, std::hash::Hash)]
+#[derive(Clone, PartialEq, Eq, std::hash::Hash, TypePath)]
 enum Content {
     Panel,
     Button,

--- a/examples/multiple_same_components.rs
+++ b/examples/multiple_same_components.rs
@@ -4,11 +4,13 @@ use bevy_ninepatch::*;
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     App::default()
-        .add_plugins(DefaultPlugins)
-        // Add the `NinePatchPlugin` plugin
-        .add_plugin(NinePatchPlugin::<()>::default())
-        .add_startup_system(setup)
-        .add_system(set_content)
+        .add_plugins((
+            DefaultPlugins,
+            // Add the `NinePatchPlugin` plugin
+            NinePatchPlugin::<()>::default(),
+        ))
+        .add_systems(Startup, setup)
+        .add_systems(Update, set_content)
         .run();
 
     Ok(())
@@ -36,7 +38,8 @@ fn setup(
                     top: Val::Auto,
                     bottom: Val::Px(0.),
                 },
-                size: Size::new(Val::Px(300.), Val::Px(80.)),
+                width: Val::Px(300.),
+                height: Val::Px(80.),
 
                 justify_content: JustifyContent::Center,
                 align_items: AlignItems::Center,
@@ -62,7 +65,8 @@ fn setup(
                     top: Val::Auto,
                     bottom: Val::Px(0.),
                 },
-                size: Size::new(Val::Px(300.), Val::Px(80.)),
+                width: Val::Px(300.),
+                height: Val::Px(80.),
 
                 justify_content: JustifyContent::Center,
                 align_items: AlignItems::Center,

--- a/examples/plugin.rs
+++ b/examples/plugin.rs
@@ -4,10 +4,12 @@ use bevy_ninepatch::{NinePatchBuilder, NinePatchBundle, NinePatchData, NinePatch
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     App::default()
-        .add_plugins(DefaultPlugins)
-        // Add the `NinePatchPlugin` plugin
-        .add_plugin(NinePatchPlugin::<()>::default())
-        .add_startup_system(setup)
+        .add_plugins((
+            DefaultPlugins,
+            // Add the `NinePatchPlugin` plugin
+            NinePatchPlugin::<()>::default(),
+        ))
+        .add_systems(Startup, setup)
         .run();
 
     Ok(())
@@ -31,7 +33,8 @@ fn setup(
                 margin: UiRect::all(Val::Auto),
                 justify_content: JustifyContent::Center,
                 align_items: AlignItems::Center,
-                size: Size::new(Val::Px(500.), Val::Px(300.)),
+                width: Val::Px(500.),
+                height: Val::Px(300.),
                 ..Default::default()
             },
             nine_patch_data: NinePatchData {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,7 +11,7 @@
 #![doc = include_str!("../README.md")]
 
 mod ninepatch;
-pub use ninepatch::{NinePatch, NinePatchBuilder, NinePatchContent, Patch};
+pub use ninepatch::{NinePatch, NinePatchBuilder, NinePatchContent, Patch, Size};
 
 mod plugin;
 pub use plugin::*;

--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -1,10 +1,10 @@
-use bevy::prelude::*;
+use bevy::{prelude::*, reflect::TypePath};
 
 use crate::ninepatch::*;
 
 /// State of the current `NinePatch`
 #[derive(Debug, Clone, Component)]
-pub struct NinePatchData<T: Clone + Send + Sync + Eq + std::hash::Hash + 'static> {
+pub struct NinePatchData<T: Clone + Send + Sync + Eq + std::hash::Hash + TypePath + 'static> {
     /// Handle of the texture
     pub texture: Handle<Image>,
     /// Handle to the `NinePatchBuilder`
@@ -15,7 +15,9 @@ pub struct NinePatchData<T: Clone + Send + Sync + Eq + std::hash::Hash + 'static
     pub content: Option<std::collections::HashMap<T, Entity>>,
 }
 
-impl<T: Clone + Send + Sync + Eq + std::hash::Hash + 'static> Default for NinePatchData<T> {
+impl<T: Clone + Send + Sync + Eq + std::hash::Hash + TypePath + 'static> Default
+    for NinePatchData<T>
+{
     fn default() -> Self {
         NinePatchData {
             texture: Default::default(),
@@ -26,7 +28,9 @@ impl<T: Clone + Send + Sync + Eq + std::hash::Hash + 'static> Default for NinePa
     }
 }
 
-impl<T: Clone + Send + Sync + Default + Eq + std::hash::Hash + 'static> NinePatchData<T> {
+impl<T: Clone + Send + Sync + Default + Eq + std::hash::Hash + TypePath + 'static>
+    NinePatchData<T>
+{
     /// Create a NinePathData with content when there is only one content
     pub fn with_single_content(
         texture: Handle<Image>,
@@ -46,7 +50,7 @@ impl<T: Clone + Send + Sync + Default + Eq + std::hash::Hash + 'static> NinePatc
 
 #[derive(Bundle)]
 /// Component Bundle to place the NinePatch
-pub struct NinePatchBundle<T: Clone + Send + Sync + Eq + std::hash::Hash + 'static> {
+pub struct NinePatchBundle<T: Clone + Send + Sync + Eq + std::hash::Hash + TypePath + 'static> {
     /// Style of this UI node
     pub style: Style,
     /// State of the `NinePatch`
@@ -59,7 +63,9 @@ pub struct NinePatchBundle<T: Clone + Send + Sync + Eq + std::hash::Hash + 'stat
     pub global_transform: GlobalTransform,
 }
 
-impl<T: Clone + Send + Sync + Eq + std::hash::Hash + 'static> Default for NinePatchBundle<T> {
+impl<T: Clone + Send + Sync + Eq + std::hash::Hash + TypePath + 'static> Default
+    for NinePatchBundle<T>
+{
     fn default() -> Self {
         NinePatchBundle {
             style: Default::default(),
@@ -84,15 +90,17 @@ impl<T: Clone + Send + Sync + 'static> Default for NinePatchPlugin<T> {
         }
     }
 }
-impl<T: Clone + Send + Sync + Eq + std::hash::Hash + 'static> Plugin for NinePatchPlugin<T> {
+impl<T: Clone + Send + Sync + Eq + std::hash::Hash + TypePath + 'static> Plugin
+    for NinePatchPlugin<T>
+{
     fn build(&self, app: &mut App) {
         app.add_asset::<NinePatchBuilder<T>>()
-            .add_system(create_ninepatches::<T>);
+            .add_systems(Update, create_ninepatches::<T>);
     }
 }
 
 #[allow(clippy::type_complexity)]
-fn create_ninepatches<T: Clone + Send + Sync + Eq + std::hash::Hash + 'static>(
+fn create_ninepatches<T: Clone + Send + Sync + Eq + std::hash::Hash + TypePath + 'static>(
     mut commands: Commands,
     mut nine_patches: ResMut<Assets<NinePatchBuilder<T>>>,
     mut textures: ResMut<Assets<Image>>,


### PR DESCRIPTION
Quick and dirty port to bevy 0.11

* created a `Size` type to replace bevy's.

## TODO
* [ ] Need to double check Val::Undefined -> Val::Px(0.) conversions make sense. I suspect some of them are wrong
* [ ] Left a bunch of todo!'s on some matches for the `Val` viewport options.